### PR TITLE
Fix locale fa loading based on moment documentation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -780,8 +780,8 @@ jMoment.jIsLeapYear = jalaali.isLeapJalaaliYear
 jMoment.loadPersian = function (args) {
   var usePersianDigits =  args !== undefined && args.hasOwnProperty('usePersianDigits') ? args.usePersianDigits : false
   var dialect =  args !== undefined && args.hasOwnProperty('dialect') ? args.dialect : 'persian'
-  moment.locale('fa', null)
-  moment.defineLocale('fa'
+  moment.locale('fa')
+  moment.updateLocale('fa'
   , { months: ('ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر').split('_')
     , monthsShort: ('ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر').split('_')
     , weekdays:

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = jMoment
 
 var moment = require('moment')
   , jalaali = require('jalaali-js')
+require('moment/locale/fa')
 
 /************************************
     Constants


### PR DESCRIPTION
# Motivation
When you use the `moment.loadPersian()` function you will face an error that says the `fa` locale is not loaded.
Based on [this document](http://momentjs.com/docs/#/use-it/browserify/) of `moment` this is a bug that prevents `moment.locale` from being loaded. And recommended solution is using this workaround:
```
var moment = require('moment');
require('moment/locale/cs');
console.log(moment.locale()); // cs
```
I applied this to solve the problem. And this PR also fix the #131.

And we want to change the `fa` locale using the `moment.defineLocale` function but we should use the `moment.updateLocale()` to change an existing locale. `moment.defineLocale()` should only be used for creating a new locale based on [this](http://momentjs.com/docs/#/customization/).