### PR TITLE
Deprecation warning :: Fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -624,7 +624,7 @@ jMoment.fn.jMonth = function (input) {
     , g
   if (input != null) {
     if (typeof input === 'string') {
-      input = this.lang().jMonthsParse(input)
+      input = this.localeData().jMonthsParse(input)
       if (typeof input !== 'number')
         return this
     }


### PR DESCRIPTION
Using `localeData` function instead of `lang` function.

Please refer to this [page section](https://momentjs.com/docs/#/i18n/instance-locale/), for more info...