### PR TITLE
fix problem with year larger than 3177

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,9 @@ function normalizeUnits(units) {
 
 function setDate(m, year, month, date) {
   var d = m._d
+  if (isNaN(year)) {
+    m._isValid = false
+  }
   if (m._isUTC) {
     /*eslint-disable new-cap*/
     m._d = new Date(Date.UTC(year, month, date,
@@ -392,6 +395,8 @@ function dateFromArray(config) {
     config._isValid = false
   g = toGregorian(jy, jm, jd)
   j = toJalaali(g.gy, g.gm, g.gd)
+  if (isNaN(g.gy))
+    config._isValid = false
   config._jDiff = 0
   if (~~j.jy !== jy)
     config._jDiff += 1
@@ -507,6 +512,7 @@ function jWeekOfYear(mom, firstDayOfWeek, firstDayOfWeekOfYear) {
 /************************************
     Top Level Functions
 ************************************/
+var maxTimestamp = 57724432199999
 
 function makeMoment(input, format, lang, strict, utc) {
   if (typeof lang === 'boolean') {
@@ -553,6 +559,9 @@ function makeMoment(input, format, lang, strict, utc) {
   extend(jm, m)
   if (strict && format && jm.isValid()) {
     jm._isValid = jm.format(origFormat) === origInput
+  }
+  if (m._d.getTime() > maxTimestamp) {
+    jm._isValid = false
   }
   return jm
 }
@@ -687,6 +696,9 @@ jMoment.fn.add = function (val, units) {
     this.jMonth(this.jMonth() + val)
   } else {
     moment.fn.add.call(this, val, units)
+    if (isNaN(this.jYear())) {
+      this._isValid = false
+    }
   }
   return this
 }
@@ -874,15 +886,31 @@ jMoment.jConvert =  { toJalaali: toJalaali
 ************************************/
 
 function toJalaali(gy, gm, gd) {
-  var j = jalaali.toJalaali(gy, gm + 1, gd)
-  j.jm -= 1
-  return j
+  try {
+    var j = jalaali.toJalaali(gy, gm + 1, gd)
+    j.jm -= 1
+    return j
+  } catch (e) {
+    return {
+      jy: NaN
+      , jm: NaN
+      , jd: NaN
+    }
+  }
 }
 
 function toGregorian(jy, jm, jd) {
-  var g = jalaali.toGregorian(jy, jm + 1, jd)
-  g.gm -= 1
-  return g
+  try {
+    var g = jalaali.toGregorian(jy, jm + 1, jd)
+    g.gm -= 1
+    return g
+  } catch (e) {
+    return {
+      gy: NaN
+      , gm: NaN
+      , gd: NaN
+    }
+  }
 }
 
 /*

--- a/test.js
+++ b/test.js
@@ -123,7 +123,51 @@ describe('moment', function() {
       m = moment('60 5 31', ['jYY jM jD', 'YY M D'])
       m.format('jYY-jMM-jDD').should.be.equal('60-05-31')
     })
-  })
+
+
+    it('should return valid moment instance if years is less than 3178', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.format('jYYYY-jMM-jDD').should.be.equal('3177-01-01')
+    })
+
+      it('should return invalid moment instance if years is larger than 3177 (Jalali)', function () {
+      var m = moment('3178-01-01', 'jYYYY-jMM-jDD')
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (Gregorian)', function () {
+      var m = moment('9999-01-01','YYYY-MM-DD')
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+
+    it('should return invalid moment instance if years is larger than 3177 (timestamp)', function () {
+      var m = moment(64060576200000)
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (timestamp)', function () {
+      var m = moment(new Date(64060576200000))
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+})
 
   describe('#format', function() {
     it('should work normally when there is no Jalaali token', function() {
@@ -299,6 +343,16 @@ describe('moment', function() {
 
     it('should also has jYears alias', function() {
       moment.fn.jYear.should.be.equal(moment.fn.jYears)
+    })
+
+    it('should return invalid moment instance if years is larger than 31778', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.jYear(3178)
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
     })
   })
 
@@ -710,6 +764,46 @@ describe('moment', function() {
       moment(m).add(2, 'jyear').format(jf).should.be.equal('1393/12/29')
       moment(m).add(3, 'jyear').format(jf).should.be.equal('1394/12/29')
       moment(m).add(4, 'jyear').format(jf).should.be.equal('1395/12/30')
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (add year)', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.add(1, 'jyear')
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (add month)', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.add(12, 'jmonth')
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (add day)', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.add(365, 'day')
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
+    })
+
+    it('should return invalid moment instance if years is larger than 3177 (add seconds)', function () {
+      var m = moment('3177-01-01', 'jYYYY-jMM-jDD')
+      m.add(365 * 3600 * 24, 'seconds') // 365 days
+
+      m.isValid().should.be.false
+      m.jYear().should.be.NaN
+      m.jMonth().should.be.NaN
+      m.jDate().should.be.NaN
     })
   })
 


### PR DESCRIPTION
passing a date related to the year larger than 3177 is passed to Jalali moment will cause throwing an exception.

in this PR few tests added for this problem and fixed

when the year is larger than 3177, an invalid instance will be returned

example error:
```
     Error: Invalid Jalaali year 3178
      at jalCal (node_modules/jalaali-js/index.js:94:11)
      at j2d (node_modules/jalaali-js/index.js:142:11)
      at Object.toGregorian (node_modules/jalaali-js/index.js:33:14)
      at toGregorian (index.js:883:19)
      at F.jMoment.fn.jYear (index.js:611:9)
      at F.jMoment.fn.jMonth (index.js:632:10)
      at F.jMoment.fn.add (index.js:687:10)
      at Context.<anonymous> (test.js:781:9)
```