### PR TITLE
Fix endOf bug when day light saving interferes with it

### DIFF
--- a/test.js
+++ b/test.js
@@ -659,6 +659,11 @@ describe('moment', function() {
       m = moment('1980-05-15 07:10:20')
       m.endOf('week').format('jYYYY-jMM-jDD HH:mm:ss').should.be.equal('1359-02-26 23:59:59')
     })
+
+    it('should work even when day light saving interferes', function () {
+      var m = moment('2020-03-21 07:10:20')
+      m.endOf('week').format('jYYYY-jMM-jDD HH:mm:ss').should.be.equal('1399-01-08 23:59:59')
+    })
   })
 
   describe('#isValid', function() {


### PR DESCRIPTION
Description:
--------------------
`endOf` has bug when it's used to get end of week for 2020-03-21 until 2020-03-27.  

Steps To Reproduce:
-------------------------------

  Run this code snippet:  

```
moment('2020-03-21 07:10:20').endOf('week')
```  

  Expected value: `2020-03-27`
  What it returns: `2020-03-28`


Notes About Code
-------------------------------
Please note that I've largely copied contents of `endOf` function from `moment` lib itself. Specifically, please see this [switch](https://github.com/moment/moment/blob/13a61b285c095bda7ea8e33156090ea5ccfeaef1/src/lib/moment/start-end-of.js#L91).  
I've tried to stick to code conventions of this repo, but if there's any problem please let me know.